### PR TITLE
fix: rename types

### DIFF
--- a/src/classes/pgmq.ts
+++ b/src/classes/pgmq.ts
@@ -1,5 +1,5 @@
 import { Pool } from "pg"
-import { parseDbMessage } from "./message"
+import { parseDbMessage } from "./types"
 import {
   archiveQuery,
   createQueueQuery,

--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -1,6 +1,6 @@
 import { Pool } from "pg"
 import { archiveQuery, deleteQuery, readQuery } from "./queries"
-import { parseDbMessage } from "./message"
+import { parseDbMessage } from "./types"
 
 export class Queue {
   private pool: Pool

--- a/src/classes/types.ts
+++ b/src/classes/types.ts
@@ -1,4 +1,4 @@
-export interface Types<T> {
+export interface Message<T> {
   msgId: number
   readCount: number
   enqueuedAt: Date
@@ -14,7 +14,7 @@ interface DbMessage {
   message: string
 }
 
-export function parseDbMessage<T>(msg: DbMessage): Types<T> {
+export function parseDbMessage<T>(msg: DbMessage): Message<T> {
   if (msg == null) return msg
   return {
     msgId: parseInt(msg.msg_id),

--- a/src/classes/types.ts
+++ b/src/classes/types.ts
@@ -1,4 +1,4 @@
-export interface Message<T> {
+export interface Types<T> {
   msgId: number
   readCount: number
   enqueuedAt: Date
@@ -14,7 +14,7 @@ interface DbMessage {
   message: string
 }
 
-export function parseDbMessage<T>(msg: DbMessage): Message<T> {
+export function parseDbMessage<T>(msg: DbMessage): Types<T> {
   if (msg == null) return msg
   return {
     msgId: parseInt(msg.msg_id),


### PR DESCRIPTION
# Generated description

Dear maintainer, below is a concise technical summary of the changes proposed in this PR:
<p>Refactor import paths in <code>pgmq.ts</code> and <code>queue.ts</code> to use <code>parseDbMessage</code> from <code>types</code> instead of <code>message</code>, ensuring consistent type usage across the codebase.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://main.baz.ninja/changes/baz-scm/pgmq-ts/11?tool=ast&topic=Import+Refactoring>Import Refactoring</a>
        </td><td>Refactor import paths in <code>pgmq.ts</code> and <code>queue.ts</code> to use <code>parseDbMessage</code> from <code>types</code> instead of <code>message</code>, ensuring consistent type usage across the codebase.<details><summary>Modified files (2)</summary><ul><li>src/classes/pgmq.ts</li>
<li>src/classes/queue.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>Email</th><th>Commit</th><th>Date</th></tr><tr><td>nimrod@baz.co</td><td>feat-Add-Queue-struct-...</td><td>October 11, 2024</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @nimrodkor and the rest of your team on <a href=https://baz.co/login>(Baz)</a>.
    