### PR TITLE
fix: Connection release on message read

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -15,6 +15,7 @@ export class Queue {
     const query = readQuery(this.name, vt)
     const conn = await this.pool.connect()
     const result = await conn.query(query)
+    conn.release()
     return parseDbMessage<T>(result.rows[0])
   }
 


### PR DESCRIPTION
# User description
fixed connection release on message read

---

# Generated description

Dear maintainer, below is a concise technical summary of the changes proposed in this PR:
<p>Fix the connection release issue in the <code>Queue</code> class by ensuring the connection is released after executing the <code>readQuery</code> function.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://main.baz.ninja/changes/baz-scm/pgmq-ts/19?tool=ast&topic=Connection+Release>Connection Release</a>
        </td><td>Ensure the connection is released after executing the <code>readQuery</code> function in the <code>Queue</code> class.<details><summary>Modified files (1)</summary><ul><li>src/classes/queue.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>Email</th><th>Commit</th><th>Date</th></tr><tr><td>nimrod@baz.co</td><td>fix-rename-types-11</td><td>October 11, 2024</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @michaelAppsforce and the rest of your team on <a href=https://baz.co/login>(Baz)</a>.
    