### PR TITLE
feat: return nullable message from readMessage

### DIFF
--- a/src/classes/pgmq.ts
+++ b/src/classes/pgmq.ts
@@ -91,14 +91,17 @@ export class Pgmq {
    * @param vt - the visibility timeout of the message. The visibility timeout
    * defines the time a message will stay hidden after being retrieved, allowing other
    * consumers to process it later if it was not removed from the queue
-   * @return the whole [message]{@link Message}, including the id, read count and the actual message within
+   * @return the whole [message]{@link Message}, including the id, read count and the actual message within if exists
    */
   public async readMessage<T>(queue: string, vt: number) {
     const connection = await this.pool.connect()
     const query = readQuery(queue, vt)
     const msg = await connection.query(query)
     connection.release()
-    return parseDbMessage<T>(msg.rows[0])
+    if (msg.rows.length > 0) {
+      return parseDbMessage<T>(msg.rows[0])
+    }
+    return null
   }
 
   /**

--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -11,12 +11,22 @@ export class Queue {
     this.name = name
   }
 
+  /**
+   * Read a message from the queue
+   * @param vt - the visibility timeout of the message. The visibility timeout
+   * defines the time a message will stay hidden after being retrieved, allowing other
+   * consumers to process it later if it was not removed from the queue
+   * @return the whole [message]{@link Message}, including the id, read count and the actual message within if exists
+   */
   public async readMessage<T>(vt = 0) {
     const query = readQuery(this.name, vt)
     const conn = await this.pool.connect()
     const result = await conn.query(query)
     conn.release()
-    return parseDbMessage<T>(result.rows[0])
+    if (result.rows.length > 0) {
+      return parseDbMessage<T>(result.rows[0])
+    }
+    return null
   }
 
   /**


### PR DESCRIPTION
# Generated description

Dear maintainer, below is a concise technical summary of the changes proposed in this PR:
<p>Modify the <code>readMessage</code> function in both <code>Pgmq</code> and <code>Queue</code> classes to return a nullable message. This change ensures that if no message is available in the queue, the function returns null instead of attempting to parse a non-existent message. The update involves checking the length of the result set before parsing.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://main.baz.ninja/changes/baz-scm/pgmq-ts/25?tool=ast&topic=Nullable+Message+Handling>Nullable Message Handling</a>
        </td><td>Update the <code>readMessage</code> function in both <code>Pgmq</code> and <code>Queue</code> classes to handle cases where no message is available by returning null.<details><summary>Modified files (2)</summary><ul><li>src/classes/pgmq.ts</li>
<li>src/classes/queue.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>Email</th><th>Commit</th><th>Date</th></tr><tr><td>nimrod@baz.co</td><td>feat-Close-connection-...</td><td>October 22, 2024</td></tr>
<tr><td>106229897+michaelAppsf...</td><td>fix-connection-release...</td><td>October 20, 2024</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @nimrodkor and the rest of your team on <a href=https://baz.co/login>(Baz)</a>.
    