### PR TITLE
fix: prevent duplicate message reads with transaction handling

### DIFF
--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -1,6 +1,7 @@
 import { Pool } from "pg"
 import { archiveQuery, deleteQuery, readQuery } from "./queries"
 import { parseDbMessage } from "./types"
+import { executeQueryWithTransaction } from "./utils"
 
 export class Queue {
   private pool: Pool
@@ -20,9 +21,7 @@ export class Queue {
    */
   public async readMessage<T>(vt = 0) {
     const query = readQuery(this.name, vt)
-    const conn = await this.pool.connect()
-    const result = await conn.query(query)
-    conn.release()
+    const result = await executeQueryWithTransaction(this.pool, query)
     if (result.rows.length > 0) {
       return parseDbMessage<T>(result.rows[0])
     }

--- a/src/classes/utils.ts
+++ b/src/classes/utils.ts
@@ -1,0 +1,32 @@
+import { Pool, QueryResult } from "pg"
+
+/**
+ * Execute a query with proper transaction handling and connection management
+ * @param pool - The connection pool to use
+ * @param query - The query to execute
+ * @returns The query result
+ */
+export async function executeQueryWithTransaction(
+  pool: Pool,
+  query: string
+): Promise<QueryResult> {
+  const client = await pool.connect()
+  
+  try {
+    await client.query('BEGIN')
+    const result = await client.query(query)
+    await client.query('COMMIT')
+    return result
+  } catch (error) {
+    try {
+      await client.query('ROLLBACK')
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (rollbackError) {
+      // Ignore rollback errors
+    }
+    throw error
+  } finally {
+    // This ensures connection is always released, even if there's an error
+    client.release()
+  }
+}

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -9,6 +9,7 @@ interface TestMessage {
   repo: string
   metadata: {
     site: string
+    index?: number
   }
 }
 
@@ -111,6 +112,77 @@ describe("Integration tests", () => {
       expect(msg?.readCount).to.be.gt(0)
       const res = await queue.deleteMessage(id)
       expect(res).to.eq(id)
+    })
+  })
+
+  describe.skip("Test message reads", () => {
+    const name = "test_reads"
+    const pgmq = new PGMQ(process.env.DATABASE_URL || "")
+    before(async () => {
+      await pgmq.createQueue(name)
+      // Write 1000 messages to the queue
+      for (const i of Array(1000).keys()) {
+        console.log(`Sending message ${i}`)
+        await pgmq.sendMessage<TestMessage>(
+          name,
+          {
+            org: "test",
+            repo: "burst",
+            metadata: {
+              site: "baz.co",
+              index: i,
+            },
+          },
+          0
+        )
+      }
+    })
+
+    after(async () => {
+      await pgmq.end()
+    })
+
+    it("All messages should be read precisely once", async () => {
+      const readMessages = new Set<number>()
+      let runs = 0
+      const queue = pgmq.getQueue(name)
+      while (true) {
+        runs++
+        const messages = await Promise.all([
+          queue.readMessage<TestMessage>(60),
+          queue.readMessage<TestMessage>(60),
+          queue.readMessage<TestMessage>(60),
+          queue.readMessage<TestMessage>(60),
+        ])
+        for (const m of messages) {
+          if (m) {
+            const index = m.message.metadata.index
+            if (index === undefined) {
+              assert.fail(`Message with index ${m.msgId} has no index`)
+            } else {
+              console.log(`Read message ${m.msgId}`)
+            }
+            if (readMessages.has(m.msgId)) {
+              assert.fail(
+                `Message with index ${m.msgId} was read ${m.readCount} times by this thread`
+              )
+            }
+            if (m.readCount > 1) {
+              assert.fail(
+                `Message with index ${m.msgId} was read ${m.readCount} times on another thread`
+              )
+            }
+            readMessages.add(m.msgId)
+          }
+        }
+        console.log(`Read ${readMessages.size} distinct messages`)
+        if (readMessages.size === 1000) {
+          break
+        }
+        if (runs > 1000) {
+          assert.fail(`Run ${readMessages.size} distinct messages`)
+        }
+      }
     })
   })
 })

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -148,12 +148,10 @@ describe("Integration tests", () => {
       const queue = pgmq.getQueue(name)
       while (true) {
         runs++
-        const messages = await Promise.all([
-          queue.readMessage<TestMessage>(60),
-          queue.readMessage<TestMessage>(60),
-          queue.readMessage<TestMessage>(60),
-          queue.readMessage<TestMessage>(60),
-        ])
+        // Create an array of 4 promises using Array.from for better readability
+        const messages = await Promise.all(
+          Array.from({ length: 4 }, () => queue.readMessage<TestMessage>(60))
+        )
         for (const m of messages) {
           if (m) {
             const index = m.message.metadata.index
@@ -180,7 +178,7 @@ describe("Integration tests", () => {
           break
         }
         if (runs > 1000) {
-          assert.fail(`Run ${readMessages.size} distinct messages`)
+          assert.fail(`Read ${readMessages.size} distinct messages`)
         }
       }
     })


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://main.baz.ninja/changes/baz-scm/pgmq-ts/35?tool=ast&topic=Transaction+Handling>Transaction Handling</a>
        </td><td>Implements transaction handling for message reads to prevent duplicate reads<details><summary>Modified files (3)</summary><ul><li>src/classes/utils.ts</li>
<li>src/classes/queue.ts</li>
<li>src/classes/pgmq.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nimrodkor</td><td>feat-return-nullable-m...</td><td>October 22, 2024</td></tr>
<tr><td>michaelAppsforce</td><td>fix-connection-release...</td><td>October 20, 2024</td></tr></table></details></td></tr>
<tr><td><a href=https://main.baz.ninja/changes/baz-scm/pgmq-ts/35?tool=ast&topic=Integration+Testing>Integration Testing</a>
        </td><td>Adds a new integration test to verify that all messages are read exactly once<details><summary>Modified files (1)</summary><ul><li>test/integration.spec.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nimrodkor</td><td>fix-Improve-test-names-27</td><td>October 31, 2024</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Join @nimrodkor and the rest of your team on <a href=https://main.baz.ninja/changes/baz-scm/pgmq-ts/35?tool=ast>(Baz)</a>.
    