### PR TITLE
feat: accept pg PoolConfig options in the Pgmq constructor

### DIFF
--- a/src/classes/pgmq.ts
+++ b/src/classes/pgmq.ts
@@ -1,4 +1,4 @@
-import { Pool } from "pg"
+import { Pool, PoolConfig } from "pg"
 import { parseDbMessage } from "./types"
 import {
   archiveQuery,
@@ -21,12 +21,17 @@ const BIGGEST_CONCAT = "archived_at_idx_"
 const MAX_PGMQ_QUEUE_LEN = NAMELEN - 1 - BIGGEST_CONCAT.length
 
 /** This is the central class this library exports
- * @constructor requires a valid PG connection string. Example: postgresql://user:password@localhost:5432/pgmq  **/
+ * @constructor requires a valid PG connection string. Example: postgresql://user:password@localhost:5432/pgmq
+ * Optionally takes pg PoolConfig options, e.g. { ssl: { ca, checkServerIdentity } } for a
+ * server whose certificate needs a private CA.  **/
 export class Pgmq {
   private readonly pool: Pool
 
-  public constructor(connectionString: string) {
-    this.pool = new Pool({ connectionString })
+  public constructor(
+    connectionString: string,
+    poolConfig?: Omit<PoolConfig, "connectionString">
+  ) {
+    this.pool = new Pool({ connectionString, ...poolConfig })
   }
 
   public async end() {

--- a/src/classes/pgmq.ts
+++ b/src/classes/pgmq.ts
@@ -31,7 +31,7 @@ export class Pgmq {
     connectionString: string,
     poolConfig?: Omit<PoolConfig, "connectionString">
   ) {
-    this.pool = new Pool({ connectionString, ...poolConfig })
+    this.pool = new Pool({ ...poolConfig, connectionString })
   }
 
   public async end() {


### PR DESCRIPTION
## Why

The constructor builds its pool from a connection string alone:

```ts
public constructor(connectionString: string) {
  this.pool = new Pool({ connectionString })
}
```

so callers can't pass `ssl`. That blocks any deployment whose database presents a certificate signed by a private CA. Concretely, Baz self-hosted on GCP: Cloud SQL over private IP signs its server certificate with a **per-instance** CA, and the only SAN is `<uid>.<region>.sql.goog`, which resolves neither publicly nor in-cluster. node-postgres verifies the chain *and* the hostname under every `sslmode`, so a caller needs to supply `{ ca }` and override `checkServerIdentity` — neither of which is expressible in a connection string.

The only workaround today is `sslmode=no-verify` in the URL, which authenticates nothing. With this change the caller can verify the chain against the instance's own CA (which signs exactly one server) while skipping the unsatisfiable hostname check.

## What

```ts
public constructor(
  connectionString: string,
  poolConfig?: Omit<PoolConfig, "connectionString">
) {
  this.pool = new Pool({ ...poolConfig, connectionString })
}
```

Optional second argument, spread **before** `connectionString` so the explicit argument always wins — including for callers that bypass the `Omit` type (plain JS, or anything typed `any`). Verified:

```
spread last  (rejected): postgres://wrong/db
spread first (this PR):  postgres://right/db
```

Existing callers are unaffected — `new Pgmq(url)` behaves exactly as before.

Caller side, for reference:

```ts
new PGMQ(url, { ssl: { ca, checkServerIdentity: () => undefined } })
```

`tsc --noEmit` and `eslint src` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)